### PR TITLE
Add CentOS container with web server and MariaDB

### DIFF
--- a/httpd/centos7/Dockerfile
+++ b/httpd/centos7/Dockerfile
@@ -6,7 +6,7 @@ LABEL Vendor="CentOS" \
 
 
 RUN yum -y --setopt=tsflags=nodocs update && \
-    yum -y --setopt=tsflags=nodocs install httpd && \
+    yum -y --setopt=tsflags=nodocs install httpd mariadb-server && \
     yum clean all
 
 EXPOSE 80

--- a/httpd/centos7/run-httpd.sh
+++ b/httpd/centos7/run-httpd.sh
@@ -5,4 +5,7 @@
 # if it thinks it is already running.
 rm -rf /run/httpd/* /tmp/httpd*
 
+# Start MariaDB service
+systemctl start mariadb
+
 exec /usr/sbin/apachectl -DFOREGROUND

--- a/mariadb/centos7/Dockerfile
+++ b/mariadb/centos7/Dockerfile
@@ -8,10 +8,9 @@ LABEL Version=5.5.41
 LABEL Build docker build --rm --tag centos/mariadb55 .
 
 RUN yum -y install --setopt=tsflags=nodocs epel-release && \ 
-    yum -y install --setopt=tsflags=nodocs mariadb-server bind-utils pwgen psmisc hostname && \ 
+    yum -y install --setopt=tsflags=nodocs mariadb-server bind-utils pwgen psmisc hostname httpd && \ 
     yum -y erase vim-minimal && \
     yum -y update && yum clean all
-
 
 # Fix permissions to allow for running on openshift
 COPY fix-permissions.sh ./
@@ -30,5 +29,5 @@ VOLUME /var/lib/mysql
 # everywhere else
 USER 27
 
-EXPOSE 3306
-CMD ["mysqld_safe"]
+EXPOSE 3306 80
+CMD ["mysqld_safe", "httpd"]

--- a/mariadb/centos7/docker-entrypoint.sh
+++ b/mariadb/centos7/docker-entrypoint.sh
@@ -57,4 +57,7 @@ if [ "$1" = 'mysqld_safe' ]; then
 	
 fi
 
+# Start httpd service
+systemctl start httpd
+
 exec "$@"


### PR DESCRIPTION
Add MariaDB installation and startup to the CentOS 7 httpd Dockerfile and run script, and add httpd installation and startup to the CentOS 7 MariaDB Dockerfile and entrypoint script.

* **httpd/centos7/Dockerfile**
  - Install MariaDB server along with httpd.
* **httpd/centos7/run-httpd.sh**
  - Start MariaDB service before starting httpd.
* **mariadb/centos7/Dockerfile**
  - Install httpd along with MariaDB server.
  - Expose port 80 for httpd.
  - Add httpd to the CMD instruction.
* **mariadb/centos7/docker-entrypoint.sh**
  - Start httpd service before executing the main command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dan1123/CentOS-Dockerfiles/pull/1?shareId=81afec86-96aa-4016-960f-a4cffc5c49bc).